### PR TITLE
fixed callback calling notation

### DIFF
--- a/clarifai_node.js
+++ b/clarifai_node.js
@@ -181,7 +181,11 @@ Clarifai.prototype._tagURL  = function( url, localId, successHandler, retry ) {
 
 Clarifai.prototype.tagURL = function( url, localId, callback ) {
 
-	this._tagURL( url, localId, callback, function() { this.tagURL( url, localId, callback ); }.bind(this) );
+  this._tagURL( url, localId,
+    function(data) { callback(null, data); },
+    function() {
+      this.tagURL( url, localId, callback );
+    }.bind(this) );
 
 }
 


### PR DESCRIPTION
Callback notation in node.js is 

```javascript
callback(error, success);
```

Whereas, the code was calling as:

```javascript
callback(response);
```

Which was causing problems with many libraries such as node.js fibers. When I tried to call it in async, it does not response back because it was calling with a different notation.

For example:

```javascript
var $wait = require('wait.for');
var $api = require('./lib/clarifai');

$wait.launchFiber(function() {
  $api.initAPI('...', '....');

  var image = 'http://clarifai.com/img/metro-north.jpg';

  // below call was not working due to callback
  // this push request now fixes it
  console.log( $wait.forMethod($api, 'tagURL', image, null) );
}
````